### PR TITLE
Fix typo in error message: "unexpecged" → "unexpected"

### DIFF
--- a/shell-scripting/greeting-v0.sh
+++ b/shell-scripting/greeting-v0.sh
@@ -61,7 +61,7 @@ main()
                 error "unknown option: $1"
                 ;;
             *)
-                error "unexpecged argument: $1"
+                error "unexpected argument: $1"
                 ;;
         esac
     done


### PR DESCRIPTION
This Pull Request fixes a typo in the error message of greeting-v0.sh. The changes include:
Correcting "unexpecged" to "unexpected" in the error output.
Ensuring the script provides accurate feedback when an invalid option is passed.
This minor fix improves the clarity and reliability of error messages.